### PR TITLE
Add timing out for test methods

### DIFF
--- a/graderutils/main.py
+++ b/graderutils/main.py
@@ -76,6 +76,8 @@ def do_tests(config):
     """
     result_groups = []
     points_total = max_points_total = tests_run = 0
+    if "testmethod_timeout" in config:
+        graderunittest.testmethod_timeout = config["testmethod_timeout"]
     for group_result in run_test_groups(config["test_groups"]):
         result_groups.append(group_result)
         points_total += group_result["points"]

--- a/graderutils/schemaobjects.py
+++ b/graderutils/schemaobjects.py
@@ -9,7 +9,7 @@ from graderutils import graderunittest
 SCHEMA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "schemas"))
 
 
-def build_schemas(version="v1_1"):
+def build_schemas(version="v1_2"):
     """
     Build all feedback schemas and the graderutils test_config schema.
     """

--- a/graderutils/schemas/test_config_v1_2.yaml
+++ b/graderutils/schemas/test_config_v1_2.yaml
@@ -1,5 +1,5 @@
 $schema: http://json-schema.org/draft-07/schema
-version: "1.1"
+version: "1.2"
 title: Test config
 type: object
 description: Graderutils runtime configuration file
@@ -9,6 +9,9 @@ properties:
   feedback_template:
     description: Custom Jinja2 template for rendering feedback
     type: string
+  testmethod_timeout:
+    description: Time in seconds, after which test method execution is timed out
+    type: integer
   format_tracebacks:
     description: Options for formatting traceback strings from specific exception classes
     type: array

--- a/graderutils/test_config.yaml
+++ b/graderutils/test_config.yaml
@@ -24,6 +24,12 @@ test_groups:
 # Paths to custom Jinja2 HTML templates that extend or replace the default template at graderutils_format/templates/feedback.html
 feedback_template: my_feedback_template.html
 
+# (Optional)
+# Set an integer value in seconds for how long each test method is allowed to run until timing out.
+# Measured with time.perf_counter and includes time spent sleeping.
+# Defaults to 60 seconds if not specified.
+testmethod_timeout: 10
+
 # Optional input validation before running test groups.
 # Successful validation is silent, i.e. if all validation tasks pass, no output is generated from the validation.
 # If at least one validation task fails, no test groups will be run, and instead the validation errors will be shown.


### PR DESCRIPTION
**What?**

These changes add a default timeout of 60 seconds for test methods to stop infinite loops etc. and to allow feedback to be shown instead of submissions getting stuck in grading. Timer used is `time.perf_counter`, since it includes time spent sleeping.

The timeout is adjustable with a new setting in `test_config.yaml` called `testmethod_timeout` that accepts an integer value.

Graderutils function `result_or_timeout` was slightly modified to raise a new `TimeoutExit` instead of `TimeoutError` so that it is able to timeout test methods even in cases where some library does `except Exception: pass` (for example: Hypothesis).

The above change also fixes an issue where `result_or_timeout` was not able to timeout a function/method where a file handle is repeatedly opened in an infinite loop without ever closing it.

The variable `testmethod_timeout` is implemented in `graderunittest.py` as a global variable. I was unable to figure out a simple solution without using a global variable. Is this fine?