### PR TITLE
Add feedback for module-level errors

### DIFF
--- a/graderutils/graderunittest.py
+++ b/graderutils/graderunittest.py
@@ -177,6 +177,11 @@ def result_or_timeout(timed_function, args=(), kwargs=None, timeout=1, timer=tim
     return running_time, result
 
 
+class ModuleLevelError(Exception):
+    def __init__(self, other):
+        self.cause = other
+
+
 def run_test_suite_in_named_module(module_name):
     """
     Load all test cases as a test suite from a test module with the given name.
@@ -186,7 +191,10 @@ def run_test_suite_in_named_module(module_name):
     loader = unittest.defaultTestLoader
     # Module output must be suppressed during import and run, since grading json is printed to stdout as well
     with contextlib.redirect_stdout(None):
-        test_module = importlib.import_module(module_name)
+        try: # Catch module-level errors
+            test_module = importlib.import_module(module_name)
+        except BaseException as e:
+            raise ModuleLevelError(e)
         test_suite = loader.loadTestsFromModule(test_module)
         # Redirect output to string stream and increase verbosity
         runner = PointsTestRunner(stream=io.StringIO(), verbosity=2)


### PR DESCRIPTION
**What?**
With these changes proper feedback is provided (instead of just saying `Unhandled exceptions occured during testing, unable to complete tests. Please notify the author of the tests.`) when module-level errors occur in grader unit tests or student's submission.

ImportErrors that often occur in grader unit tests when student names a function incorrectly are given shorter, more clear feedback:
```
ImportError: cannot import name 'is_prime' from 'primes' (/submission/user/primes.py)
```

Other errors are shown with full traceback:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/graderutils/graderunittest.py", line 195, in run_test_suite_in_named_module
    test_module = importlib.import_module(module_name)
  File "/usr/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/exercise/local_tests.py", line 8, in <module>
    from primes import is_prime
  File "/submission/user/primes.py", line 8, in <module>
    raise Exception("This is a module-level error in student submission.")
Exception: This is a module-level error in student submission.
```

Fixes #20 

**How?**
All `test_groups` specified in `test_config.yaml` fail if module-level errors occur (just like before). This is because points and max points cannot be calculated when the grader unit test module fails to be imported.

A new class called `ModuleLevelError` is introduced in order to separate module-level errors from other exceptions that might occur within grader-utils.
