### PR TITLE
Limit maximum length of stderr output (implement #22)

### DIFF
--- a/graderutils/graderunittest.py
+++ b/graderutils/graderunittest.py
@@ -9,6 +9,7 @@ import itertools
 import logging
 import re
 import signal
+import sys
 import time
 import unittest
 
@@ -189,16 +190,24 @@ def run_test_suite_in_named_module(module_name):
     Return a PointsTestResult containing the results.
     """
     loader = unittest.defaultTestLoader
-    # Module output must be suppressed during import and run, since grading json is printed to stdout as well
-    with contextlib.redirect_stdout(None):
-        try: # Catch module-level errors
-            test_module = importlib.import_module(module_name)
-        except BaseException as e:
-            raise ModuleLevelError(e)
-        test_suite = loader.loadTestsFromModule(test_module)
-        # Redirect output to string stream and increase verbosity
-        runner = PointsTestRunner(stream=io.StringIO(), verbosity=2)
-        result = runner.run(test_suite)
+    err = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(err):
+            # Module output must be suppressed during import and run, since grading json is printed to stdout as well
+            with contextlib.redirect_stdout(None):
+                try: # Catch module-level errors
+                    test_module = importlib.import_module(module_name)
+                except BaseException as e:
+                    raise ModuleLevelError(e)
+                test_suite = loader.loadTestsFromModule(test_module)
+                # Redirect output to string stream and increase verbosity
+                runner = PointsTestRunner(stream=io.StringIO(), verbosity=2)
+                result = runner.run(test_suite)
+    except BaseException:
+        raise
+    finally:
+        # Limit maximum size of the stderr output of this test group to 50kB
+        sys.stderr.write(err.getvalue()[:50000])
     return result
 
 

--- a/graderutils/graderunittest.py
+++ b/graderutils/graderunittest.py
@@ -15,7 +15,12 @@ import unittest
 
 
 logger = logging.getLogger("warnings")
+
 testmethod_timeout = 60
+
+'''Maximum string length of the stderr stream for one test module.
+If the output is longer, the rest is not included in the grading payload.'''
+TEST_MODULE_STDERR_MAX_SIZE = 50000
 
 
 class PointsTestResult(unittest.TextTestResult):
@@ -203,11 +208,9 @@ def run_test_suite_in_named_module(module_name):
                 # Redirect output to string stream and increase verbosity
                 runner = PointsTestRunner(stream=io.StringIO(), verbosity=2)
                 result = runner.run(test_suite)
-    except BaseException:
-        raise
     finally:
         # Limit maximum size of the stderr output of this test group to 50kB
-        sys.stderr.write(err.getvalue()[:50000])
+        sys.stderr.write(err.getvalue()[:TEST_MODULE_STDERR_MAX_SIZE])
     return result
 
 


### PR DESCRIPTION
**What?**
Each `test_group` specified in `test_config.yaml` now has a maximum stderr length of 50000 characters (50kB).
This means that an exercise with two test groups has a maximum stderr payload of 2*50kB = 100kB (+ possible graderutils error messages, which are not limited by size).

The limiter could be moved to `main.py` so that stderr always has a static maximum size. But then stderr of some test groups might not be visible at all, if the previous test group used all available space already.

Implements #22