### PR TITLE
Fix coverage tests ordering and small improvements

### DIFF
--- a/graderutils/graderunittest.py
+++ b/graderutils/graderunittest.py
@@ -13,6 +13,8 @@ import sys
 import time
 import unittest
 
+from graderutils import GraderUtilsError
+
 
 logger = logging.getLogger("warnings")
 
@@ -53,7 +55,7 @@ class PointsTestResult(unittest.TextTestResult):
         self.patch_message(test, "on_error")
 
 
-def points(points_on_success, msg_on_success='', msg_on_fail='', msg_on_error=''):
+def points(points_on_success, msg_on_success="The test was a success!", msg_on_fail="The test failed, reason:", msg_on_error="An error occurred:"):
     """
     Return a decorator for unittest.TestCase test methods, which patches each test method with a graderutils_points attribute.
     """
@@ -77,9 +79,9 @@ def points(points_on_success, msg_on_success='', msg_on_fail='', msg_on_error=''
                                        "stuck in an infinite loop or it runs very slowly.".format(testmethod_timeout))
                 return result
             except SystemExit as e:
-                raise Exception("Grader does not support the usage of sys.exit(), exit() or quit().") from e
+                raise GraderUtilsError("Grader does not support the usage of sys.exit(), exit() or quit().") from e
             except KeyboardInterrupt as e:
-                raise Exception("Grader does not support raising KeyboardInterrupt.") from e
+                raise GraderUtilsError("Grader does not support raising KeyboardInterrupt.") from e
         return points_patching_testmethod
     return points_decorator
 

--- a/graderutils/testcoveragemeta.py
+++ b/graderutils/testcoveragemeta.py
@@ -29,14 +29,15 @@ def load_tests(*args, **kwargs):
 ```
 in ``coverage_tests.py``
 """
-import unittest
-import coverage
 import importlib
-from io import StringIO
-import imp
 import sys
+import unittest
+from io import StringIO
+
+import coverage
 
 from graderutils import graderunittest
+
 
 class TestCoverageMeta(type):
     """
@@ -82,20 +83,17 @@ class TestCoverageMeta(type):
         covered = cov.report(include="{}.py".format(filename), show_missing=True, file=sys.stderr)
         missing = cov.analysis("{}.py".format(filename))[3]
 
-        msg_on_success = "The test was a success!"
-        msg_on_fail = "The test failed, reason:"
-        msg_on_error = "An error occurred:"
-
-        @graderunittest.points(0, msg_on_success=msg_on_success, msg_on_fail=msg_on_fail, msg_on_error=msg_on_error)
+        @graderunittest.points(0)
         def user_tests_pass(self):
             """Check if students tests pass"""
             if not result.wasSuccessful():
                 self.fail("Your tests didn't pass. Coverage tests won't be run.\n\n{}".format(stream.getvalue()))
             self.preformatted_feedback = "Run results: \n{}".format(stream.getvalue())
+
         setattr(newclass, 'test_code', user_tests_pass)
 
         def generate_test(percentage, test_num, points):
-            @graderunittest.points(points, msg_on_success=msg_on_success, msg_on_fail=msg_on_fail, msg_on_error=msg_on_error)
+            @graderunittest.points(points)
             def a_test(self):
                 if result.wasSuccessful():
                     self.assertGreaterEqual(covered, percentage,
@@ -103,14 +101,16 @@ class TestCoverageMeta(type):
                         .format(covered, missing))
                 else:
                     self.fail("Test wasn't run because your tests weren't successful")
-            a_test.__doc__ = 'Checks that test coverage is over {}%'.format(percentage)
 
-            setattr(newclass, 'test_coverage_{}'.format(test_num), a_test)
+            a_test.__doc__ = 'Checks that test coverage is over {}%'.format(percentage)
+            setattr(newclass, 'test_coverage_{:02d}'.format(test_num), a_test)
+
         iterations = len(points)
         for num, point in enumerate(points, start=1):
             generate_test((100-minimum)/iterations*num+minimum, num, point)
 
         return newclass
+
 
     def __init__(cls, clsname, bases, dct, testmodule, filename, points, minimum=0):
         super().__init__(cls, clsname, dct)

--- a/graderutils_format/templates/default.css
+++ b/graderutils_format/templates/default.css
@@ -25,8 +25,21 @@ pre {
 div.warning-messages {
     margin-top: 35px;
 }
-/* Override stylesheet default badge color inside panel-heading */
+
+/* Override stylesheet badge colors inside panel-heading since otherwise they are black */
+
+/* Error */
 div.grading-task .panel-default > .panel-heading .badge {
     color: #fff;
     background-color: #777;
+}
+/* Success */
+div.grading-task .panel-default > .panel-heading .badge.badge-success {
+    color: #fff;
+    background-color: #00803c;
+}
+/* Fail */
+div.grading-task .panel-default > .panel-heading .badge.badge-danger {
+    color: #fff;
+    background-color: #a50000;
 }


### PR DESCRIPTION
**What?**
Tests generated in `testcoveragemeta.py` are now properly ordered in the html feedback when more than 9 tests exist by changing the names of the generated tests from format `'test_coverage_{}'.format(test_num)` to `'test_coverage_{:02d}'.format(test_num)`.

Various other small changes to `testcoveragemeta.py` improve the code style and readability (imports in alphabetical order, better grouping of code, newlines). An unused import (`imp`) was also removed.

Default test result messages `The test was a success!`, `The test failed, reason:`, `An error occurred:` are moved from `testcoveragemeta.py` to `graderunittest.py`.

These messages are now shown by default in the html feedback on all tests instead of only in coverage tests. There is no reason for grader-utils not to provide these default messages (they can still be overridden in the grader unittests, if the test author so wishes). 

This also makes expanding tests that succeeded less weird by actually saying something, instead of just showing an empty box:
![image](https://user-images.githubusercontent.com/38466145/114026205-a6ff9100-987e-11eb-80c7-a36830d390a1.png)

Changed two `Exception`s in `graderunittest.py` to class `GraderUtilsError`. This error fits better and is more consistent with other parts of grader-utils, where `GraderUtilsError` is already used.

Previously, in `default.css`, default stylesheet badge colors in cases of errors had to be overridden to be gray, or else they would be black. Recent updates to the A+ stylesheet have forced all (error, success, fail) badge colors to be gray. This means that we have to override all the colors for them to be correct (gray, green, red). If the overrides are removed all points badges turn to black.

This could probably be fixed in the stylesheet. I don't think black badges are used anywhere in A+.
`_panels.scss` seems to override `.panel-default > .panel-heading .badge` to black for some reason.

![1](https://user-images.githubusercontent.com/38466145/114028470-2bebaa00-9881-11eb-87ae-6f60456ed10f.png)
