### PR TITLE
Fix #16 and other validation task bugs

### DIFF
--- a/graderutils/schemaobjects.py
+++ b/graderutils/schemaobjects.py
@@ -84,7 +84,7 @@ def validation_errors_as_test_results(errors):
     for error in errors:
         result = {
             "title": error.get("display_name", error["type"]),
-            "testOutput": error["message"],
+            "testOutput": error.get("message", "The submitted file did not pass this validation task."),
             "status": "failed",
         }
         if "description" in error:

--- a/graderutils/validation.py
+++ b/graderutils/validation.py
@@ -232,7 +232,7 @@ def get_python_syntax_errors(filename):
         ast.parse(source)
     except SyntaxError as syntax_error:
         errors["message"] = "Syntax error in {!r} at line {}:\n{}".format(
-            syntax_error.filename,
+            filename,
             syntax_error.lineno,
             syntax_error.text
         )
@@ -247,6 +247,7 @@ def get_labview_errors(filename):
             errors["message"] = "The file wasn't a proper labVIEW-file"
     return errors
 
+
 def get_xlsm_errors(filename):
     errors = {}
     with open(filename, "rb") as f:
@@ -254,6 +255,7 @@ def get_xlsm_errors(filename):
         if header != b'PK\x03\x04\x14\x00\x06\x00\x08\x00\x00\x00!\x00':
             errors["message"] = "The file wasn't a proper Excel-file with macros!"
     return errors
+
 
 def get_html_errors(filename):
     errors = {}

--- a/graderutils_format/templates/feedback.html
+++ b/graderutils_format/templates/feedback.html
@@ -45,16 +45,22 @@
                     href="#result{{ result_group_loop.index }}-{{ test_result_loop.index }}">{{ result.title }}</a>
                 <span> </span>
                 {% if result.status == "passed" %}
+                {% if maxPoints %}
                 <span class="badge badge-success">{{ result.points }} / {{ result.maxPoints }}</span>
                 <span class="label sr-only">points</span>
+                {% endif %}
                 <span class="label feedback-label label-success">Success</span>
                 {% elif result.status == "failed" %}
+                {% if maxPoints %}
                 <span class="badge badge-danger">{{ result.points }} / {{ result.maxPoints }}</span>
                 <span class="label sr-only">points</span>
+                {% endif %}
                 <span class="label feedback-label label-danger">Failed</span>
                 {% elif result.status == "error" %}
+                {% if maxPoints %}
                 <span class="badge">{{ result.points }} / {{ result.maxPoints }}</span>
                 <span class="label sr-only">points</span>
+                {% endif %}
                 <span class="label feedback-label label-default">Error</span>
                 {% endif %}
             </h5>


### PR DESCRIPTION
**What?**

**1.** When python_import attrs validation failed without raising an exception, a `KeyError` occurred. This is now fixed by adding the following default feedback message when validation fails: `The submitted file did not pass this validation task.`

**2.** In Python syntax validation the feedback looked like:
```
Syntax error in '<unknown>' at line 5:
importtt sys
```
The filename variable used was changed, and now the filename is properly displayed in the feedback.

**3.** The validation tasks do not grant points and there was an empty points badge in the html feedback when validation tasks failed.
This points badge is no longer displayed when points don't exist.