### PR TITLE
CSS/HTML cleanup and fix for screen reader behaviour

### DIFF
--- a/graderutils_format/templates/base.html
+++ b/graderutils_format/templates/base.html
@@ -17,7 +17,7 @@
     </head>
 
     <body>
-        <div class="container feedback-body">
+        <div class="container">
         {% block body %}
         {% endblock %}
         </div>

--- a/graderutils_format/templates/default.css
+++ b/graderutils_format/templates/default.css
@@ -1,9 +1,6 @@
-div.feedback-body {
-    margin-top: 15px;
-}
-/* Align all labels in grader result panels to the right side */
+/* Increase size of labels in grader result panels */
 span.feedback-label {
-    float: right;
+    font-size: 15px;
 }
 /* Add space between different test groups */
 div.grading-task {
@@ -19,27 +16,38 @@ h3.testgroup-header {
     margin-bottom: 20px;
 }
 /* Disable automatic horizontal scroll of preformatted text blocks */
-pre {
+div.panel-body pre {
     white-space: pre-wrap;
 }
 div.warning-messages {
     margin-top: 35px;
 }
-
-/* Override stylesheet badge colors inside panel-heading since otherwise they are black */
-
-/* Error */
-div.grading-task .panel-default > .panel-heading .badge {
-    color: #fff;
-    background-color: #777;
+/* Prevent title headings, badges and labels from rendering outside grader result panels */
+div.panel-default > .panel-heading {
+    overflow: hidden;
 }
-/* Success */
-div.grading-task .panel-default > .panel-heading .badge.badge-success {
+/* For centering badges and labels vertically in grader result panels */
+.vertical-center {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+/* Add space between panel titles and points badges, and increase badge size */
+div.grading-task .panel-default > .panel-heading .badge {
+    font-size: 15px;
+    margin-left: 15px;
+}
+/* Green color for badges and labels when tests pass */
+div.grading-task .panel-default > .panel-heading .green {
     color: #fff;
     background-color: #00803c;
 }
-/* Fail */
-div.grading-task .panel-default > .panel-heading .badge.badge-danger {
+/* Red color for badges and labels when tests fail */
+div.grading-task .panel-default > .panel-heading .red {
     color: #fff;
     background-color: #a50000;
+}
+/* Orange color for badges and labels when errors occur */
+div.grading-task .panel-default > .panel-heading .orange {
+    color: #fff;
+    background-color: #a6670e;
 }

--- a/graderutils_format/templates/feedback.html
+++ b/graderutils_format/templates/feedback.html
@@ -18,7 +18,7 @@
     <h1>Total points: {{ points }} of {{ maxPoints }}</h1>
     {% endif %}
     {% if testsRun %}
-    <h1><small>Total tests run: {{ testsRun }}</small></h1>
+    <h2><small>Total tests run: {{ testsRun }}</small></h2>
     {% endif %}
 </div>
 
@@ -40,30 +40,31 @@
 
     <div class="panel panel-default">
         <div class="panel-heading">
-            <h5>
+            <h4 class="pull-left">
                 <a data-toggle="collapse"
                     href="#result{{ result_group_loop.index }}-{{ test_result_loop.index }}">{{ result.title }}</a>
-                <span> </span>
+            </h4>
+            <div class="vertical-center">
                 {% if result.status == "passed" %}
-                {% if maxPoints %}
-                <span class="badge badge-success">{{ result.points }} / {{ result.maxPoints }}</span>
+                {% if result.maxPoints %}
+                <span class="badge green">{{ result.points }} / {{ result.maxPoints }}</span>
                 <span class="sr-only">points</span>
                 {% endif %}
-                <span class="label feedback-label label-success">Success</span>
+                <span class="label feedback-label green pull-right">Success</span>
                 {% elif result.status == "failed" %}
-                {% if maxPoints %}
-                <span class="badge badge-danger">{{ result.points }} / {{ result.maxPoints }}</span>
+                {% if result.maxPoints %}
+                <span class="badge red">{{ result.points }} / {{ result.maxPoints }}</span>
                 <span class="sr-only">points</span>
                 {% endif %}
-                <span class="label feedback-label label-danger">Failed</span>
+                <span class="label feedback-label red pull-right">Failed</span>
                 {% elif result.status == "error" %}
-                {% if maxPoints %}
-                <span class="badge badge-danger">{{ result.points }} / {{ result.maxPoints }}</span>
+                {% if result.maxPoints %}
+                <span class="badge orange">{{ result.points }} / {{ result.maxPoints }}</span>
                 <span class="sr-only">points</span>
+                <span class="label feedback-label orange pull-right">Error</span>
                 {% endif %}
-                <span class="label feedback-label label-danger">Error</span>
                 {% endif %}
-            </h5>
+            </div>
         </div>
         <div id="result{{ result_group_loop.index }}-{{ test_result_loop.index }}"
              class="collapse{% if result.status != "passed" %} in{% endif %}">
@@ -85,7 +86,7 @@
                 <button type="button" class="btn btn-info" data-toggle="collapse" data-target="#traceback{{ result_group_loop.index }}-{{ test_result_loop.index }}">
                   Show traceback</button>
                 <div id="traceback{{ result_group_loop.index }}-{{ test_result_loop.index }}" class="collapse">
-                  <p><pre>{{ result.fullTestOutput|e }}</pre></p>
+                    <p><pre>{{ result.fullTestOutput|e }}</pre></p>
                 </div>
                 {% endif %}
 
@@ -104,11 +105,11 @@
 {% if result_group.fullOutput %}
 <div class="panel panel-default full-test-output">
     <div class="panel-heading">
-        <h5>
+        <h4 class="pull-left">
             <a data-toggle="collapse" href="#full-test-output{{ result_group_loop.index }}">
                 Full terminal output for {{ result_group.title }}</a>
-            <span class="label feedback-label label-info">Info</span>
-        </h5>
+        </h4>
+        <span class="label feedback-label label-info vertical-center pull-right">Info</span>
     </div>
     <div id="full-test-output{{ result_group_loop.index }}" class="panel-body collapse">
         <p><pre class="feedback">{{ result_group.fullOutput|e }}</pre></p>
@@ -124,11 +125,11 @@
     {% set warnings_loop = loop %}
     <div class="panel panel-default">
         <div class="panel-heading">
-            <h5>
+            <h4>
                 <a data-toggle="collapse"
                    href="#warning-message{{ warnings_loop.index }}"
                    class="label label-info">Graderutils message</a>
-            </h5>
+            </h4>
         </div>
         <div id="warning-message{{ warnings_loop.index }}" class="panel-body collapse in">
             <pre>{{ warning|e }}</pre>


### PR DESCRIPTION
**What?**
- Feedback HTML no longer skips heading levels.

- Points badges and feedback labels are no longer inside feedback title headings, which fixes the issues where heading level was repeated multiple times by some screen readers.

- Cleaned up CSS as suggested in #13

- Set matching colors (green, red, orange) for points badges and feedback labels. This fixes the issue where bootstrap defaults badges to black inside panel-heading. It also makes it so that badges and labels have matching colors, even if bootstrap is updated later.

If there is a better way of writing the CSS/HTML, I could not figure it out.

Fixes #13, #28, #31

![7-5-2021 9-52-47](https://user-images.githubusercontent.com/38466145/117409610-0acab780-af1a-11eb-986e-3b5494fe7c38.png)
